### PR TITLE
don't stomp on request body

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -35,8 +35,9 @@ module Faraday
     end
 
     def save_response(env, status, body, headers = nil)
-      env.status = status
-      env.body = body
+      env.status       = status
+      env.request_body = env.body
+      env.body         = body
       env.response_headers = Utils::Headers.new.tap do |response_headers|
         response_headers.update headers unless headers.nil?
         yield(response_headers) if block_given?

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -252,7 +252,7 @@ module Faraday
   end
 
   class Env < Options.new(:method, :body, :url, :request, :request_headers,
-    :ssl, :parallel_manager, :params, :response, :response_headers, :status)
+    :ssl, :parallel_manager, :params, :response, :response_headers, :status, :request_body)
 
     ContentLength = 'Content-Length'.freeze
     StatusesWithoutBody = Set.new [204, 304]

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -134,6 +134,12 @@ module Adapters
         assert_equal "file integration.rb text/x-ruby #{File.size(__FILE__)}", resp.body
       end
 
+      def test_save_request_body
+        resp = post('echo') { |req| req.body = {"mah" => "body"} }
+
+        assert_equal "mah=body", resp.env.request_body
+      end
+
       def test_PUT_send_url_encoded_params
         assert_equal %(put {"name"=>"zack"}), put('echo', :name => 'zack').body
       end


### PR DESCRIPTION
- store request_body in env
- allow response to contain all the information of the request
